### PR TITLE
Add batch APIs to limit responses from Netlink

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -109,6 +109,68 @@ func (c *Conn) Close() error {
 	return newOpError("close", c.sock.Close())
 }
 
+func (c *Conn) AcquireLock() {
+	c.mu.Lock()
+}
+
+func (c *Conn) ReleaseLock() {
+	c.mu.Unlock()
+}
+
+// ExecuteRequest executes the request without parsing the response. Only to be called when the lock
+// is acquired.
+func (c *Conn) ExecuteRequest(message Message) (Message, error) {
+	req, err := c.lockedSend(message)
+	if err != nil {
+		return Message{}, err
+	}
+	return req, nil
+}
+
+// ReceiveNextBatch receive the next batch of messages for a particular request 'message'. Limit is the maximum number
+// of messages to be pulled in this iteration. Please note that this is not a hard limit and number of messages can be
+// greater than 'limit'. It means that we will stop reading once we breach 'limit'. Only to be called when the lock is
+// acquired.
+func (c *Conn) ReceiveNextBatch(message Message, limit int) ([]Message, error) {
+	replies, err := c.lockedReceiveNextBatch(limit)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := Validate(message, replies); err != nil {
+		return nil, err
+	}
+
+	return replies, nil
+}
+
+func (c *Conn) lockedReceiveNextBatch(limit int) ([]Message, error) {
+	msgs, err := c.receiveNextBatch(limit)
+	return c.validateResponse(msgs, err)
+}
+
+func (c *Conn) receiveNextBatch(limit int) ([]Message, error) {
+	// NB: All non-nil errors returned from this function *must* be of type
+	// OpError in order to maintain the appropriate contract with callers of
+	// this package.
+	//
+	// This contract also applies to functions called within this function,
+	// such as checkMessage.
+
+	var res []Message
+	for {
+		msgs, multi, err := c.receiveMsg()
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, msgs...)
+
+		if !multi || len(res) >= limit {
+			return res, nil
+		}
+	}
+}
+
 // Execute sends a single Message to netlink using Send, receives one or more
 // replies using Receive, and then checks the validity of the replies against
 // the request using Validate.
@@ -245,6 +307,10 @@ func (c *Conn) Receive() ([]Message, error) {
 // socket itself.
 func (c *Conn) lockedReceive() ([]Message, error) {
 	msgs, err := c.receive()
+	return c.validateResponse(msgs, err)
+}
+
+func (c *Conn) validateResponse(msgs []Message, err error) ([]Message, error) {
 	if err != nil {
 		c.debug(func(d *debugger) {
 			d.debugf(1, "recv: err: %v", err)
@@ -285,38 +351,44 @@ func (c *Conn) receive() ([]Message, error) {
 
 	var res []Message
 	for {
-		msgs, err := c.sock.Receive()
+		msgs, multi, err := c.receiveMsg()
 		if err != nil {
-			return nil, newOpError("receive", err)
+			return nil, err
 		}
-
-		// If this message is multi-part, we will need to perform an recursive call
-		// to continue draining the socket
-		var multi bool
-
-		for _, m := range msgs {
-			if err := checkMessage(m); err != nil {
-				return nil, err
-			}
-
-			// Does this message indicate a multi-part message?
-			if m.Header.Flags&Multi == 0 {
-				// No, check the next messages.
-				continue
-			}
-
-			// Does this message indicate the last message in a series of
-			// multi-part messages from a single read?
-			multi = m.Header.Type != Done
-		}
-
 		res = append(res, msgs...)
-
 		if !multi {
 			// No more messages coming.
 			return res, nil
 		}
 	}
+}
+
+func (c *Conn) receiveMsg() ([]Message, bool, error) {
+	msgs, err := c.sock.Receive()
+	if err != nil {
+		return nil, false, newOpError("receive", err)
+	}
+
+	// If this message is multi-part, we will need to perform an recursive call
+	// to continue draining the socket
+	var multi bool
+
+	for _, m := range msgs {
+		if err := checkMessage(m); err != nil {
+			return nil, false, err
+		}
+
+		// Does this message indicate a multi-part message?
+		if m.Header.Flags&Multi == 0 {
+			// No, check the next messages.
+			continue
+		}
+
+		// Does this message indicate the last message in a series of
+		// multi-part messages from a single read?
+		multi = m.Header.Type != Done
+	}
+	return msgs, multi, nil
 }
 
 // A groupJoinLeaver is a Socket that supports joining and leaving

--- a/conn_test.go
+++ b/conn_test.go
@@ -205,6 +205,9 @@ func TestConnReceiveNextBatch(t *testing.T) {
 
 	msg.Header.Flags |= netlink.Multi
 
+	if c.EndOfStream() {
+		t.Fatalf("Expected not to reach end of stream.")
+	}
 	if l := len(msgs); l != 2 {
 		t.Fatalf("expected 2 messages, but got: %d", l)
 	}
@@ -222,6 +225,9 @@ func TestConnReceiveNextBatch(t *testing.T) {
 
 	msg.Header.Flags |= netlink.Multi
 
+	if !c.EndOfStream() {
+		t.Fatalf("Expected to reach end of stream.")
+	}
 	if l := len(msgs); l != 1 {
 		t.Fatalf("expected 1 messages, but got: %d", l)
 	}


### PR DESCRIPTION
This PR introduces Batch APIs to limit number of messages in the response for a particular request. 
The traditional APIs fetch all the messages in a response. This can cause OOM issues where the raw response from the Netlink library is huge.